### PR TITLE
added possibility to make alt tags in images

### DIFF
--- a/livingdocs/Media/image/image.html
+++ b/livingdocs/Media/image/image.html
@@ -20,14 +20,40 @@
 		}
 	}
 </script>
+<script type="ld-conf">
+  {
+      "name": "image",
+      "label": "Image",
+      "iconUrl": "https://mms-xbrl.s3.eu-central-1.amazonaws.com/design/svg/editor/icon-image.min.svg",
+      "properties": [
+          "show-mobile-image",
+          "web-width",
+          "pdf-width"
+      ],
+      "directives": {
+          "desktop-image": {
+              "imageRatios": ["1:1", "3:2", "4:3", "16:9"],
+              "allowOriginalRatio": true
+          },
+          "mobile-image": {
+              "imageRatios": ["1:1", "3:2", "4:3", "16:9"],
+              "allowOriginalRatio": true
+          }
+      }
+  }
+</script>
 <figure class="srl-image srl-article__grid srl-article__grid--indent">
   <div class="srl-article__grid--inner">
+    <div class="lc-image__alt-text" doc-editable="alt-tag" optional data-alt-text-source="alt">
+      Write the alt text here
+    </div>
     <div class="srl-image__image-container srl-image__image-container--desktop">
-      <img class="srl-image__img srl-image__img--desktop" doc-image="desktop-image" />
+      <img class="srl-image__img srl-image__img--desktop" doc-image="desktop-image" data-alt-text-target="alt" />
     </div>
     <div class="srl-image__image-container srl-image__image-container--mobile">
-      <img class="srl-image__img srl-image__img--mobile" doc-image="mobile-image" />
+      <img class="srl-image__img srl-image__img--mobile" doc-image="mobile-image" data-alt-text-target="alt" />
     </div>
     <figcaption class="srl-linkable srl-image__caption" doc-editable="legend" doc-optional>Bildlegende</figcaption>
   </div>
 </figure>
+

--- a/livingdocs/Media/image/image.html
+++ b/livingdocs/Media/image/image.html
@@ -20,28 +20,6 @@
 		}
 	}
 </script>
-<script type="ld-conf">
-  {
-      "name": "image",
-      "label": "Image",
-      "iconUrl": "https://mms-xbrl.s3.eu-central-1.amazonaws.com/design/svg/editor/icon-image.min.svg",
-      "properties": [
-          "show-mobile-image",
-          "web-width",
-          "pdf-width"
-      ],
-      "directives": {
-          "desktop-image": {
-              "imageRatios": ["1:1", "3:2", "4:3", "16:9"],
-              "allowOriginalRatio": true
-          },
-          "mobile-image": {
-              "imageRatios": ["1:1", "3:2", "4:3", "16:9"],
-              "allowOriginalRatio": true
-          }
-      }
-  }
-</script>
 <figure class="srl-image srl-article__grid srl-article__grid--indent">
   <div class="srl-article__grid--inner">
     <div class="lc-image__alt-text" doc-editable="alt-tag" optional data-alt-text-source="alt">


### PR DESCRIPTION
Added a new field for alt tags:

```
<div class="lc-image__alt-text" doc-editable="alt-tag" optional data-alt-text-source="alt">
    Write the alt text here
</div>
```
The value of `data-alt-text-source` is binded to the value of `data-alt-text-target`. If it finds something it will be added as `alt` tag to the `img` tag within hosting and PDF.

Also you could have multiple alt tags, then it would look as follows:

```
<figure class="srl-image srl-article__grid srl-article__grid--indent">
  <div class="srl-article__grid--inner">
    <div class="lc-image__alt-text" doc-editable="alt-tag" optional data-alt-text-source="alt-desktop">
      Write the alt text for desktop here
    </div>
    <div class="lc-image__alt-text" doc-editable="alt-tag" optional data-alt-text-source="alt-mobile">
      Write the alt text for mobile here
    </div>
    <div class="srl-image__image-container srl-image__image-container--desktop">
      <img class="srl-image__img srl-image__img--desktop" doc-image="desktop-image" data-alt-text-target="alt-desktop" />
    </div>
    <div class="srl-image__image-container srl-image__image-container--mobile">
      <img class="srl-image__img srl-image__img--mobile" doc-image="mobile-image" data-alt-text-target="alt-mobile" />
    </div>
    <figcaption class="srl-linkable srl-image__caption" doc-editable="legend" doc-optional>Bildlegende</figcaption>
  </div>
</figure>
```