### PR TITLE
minify html templates in ldd-design

### DIFF
--- a/scripts/ldd/mapLdd.js
+++ b/scripts/ldd/mapLdd.js
@@ -152,7 +152,13 @@ async function mapComponents(lddJson) {
           );
           const componentHtml = readFileSync(htmlPath, { encoding: 'utf-8' });
 
-          lddComponents.push({ ...componentDeclaration, html: componentHtml });
+          lddComponents.push({ 
+            ...componentDeclaration, 
+            html: componentHtml
+                    .replaceAll(/>\s+/g, ">")
+                    .replaceAll(/\s+</g, "<")
+                    .trim()
+          });
         }
       } catch (error) {}
 


### PR DESCRIPTION
why: #101 

remove whitespaces between html open- and close-tag brackets