### PR TITLE
Feature/feintool

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 import { Command } from 'commander';
 import { readFile } from 'fs/promises';
 import {
@@ -79,8 +80,9 @@ commander
   .command('build')
   .description('Build ldd, app, pdf and word for production')
   .argument('[version]', 'The name of component or group.')
-  .action(async (version) => {
-    await build(version);
+  .option('-c, --customer <customer>', 'The customer to build for')
+  .action(async (version, options) => {
+    await build(version, options);
   });
 
 commander

--- a/scripts/build.d.ts
+++ b/scripts/build.d.ts
@@ -5,7 +5,7 @@
  * @param {string} version
  * @return {Promise<void>} A Promise that resolves when the build process is completed or rejects if an error occurs.
  */
-export function build(version: string): Promise<void>;
+export function build(version: string, options: any): Promise<void>;
 /**
  * Builds the project sequentially by executing a series of asynchronous tasks in a specific order.
  * This method is used to build the project in a predetermined sequence.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -470,7 +470,6 @@ async function buildLdd(version) {
           join(folders.root, 'livingdocs.config.json'),
           join(folders.srlOutput, 'ldd', 'design.json'),
         );
-        buildPdfCustomer()
       });
   } catch (e) {
     console.error(e);
@@ -478,7 +477,17 @@ async function buildLdd(version) {
   }
 }
 
-async function buildPdfCustomer() {
+async function buildPdfCustomer(customer) {
+  const customerDir = join(folders.root, 'pdf', 'customers', customer);
+
+  try {
+    statSync(customerDir);
+  } catch (e) {
+    console.error(`Customer ${customer} does not exist in: ` + customerDir);
+  }
+
+  console.log(`\nBuild PDF for customer ${customer}`);
+
   const lddPdfDir = join(folders.srlOutput, 'ldd', 'pdf');
   const lddJson = await readLivingDocsJson();
 
@@ -486,119 +495,114 @@ async function buildPdfCustomer() {
     const pdfDir = join(folders.srlOutput, 'pdf');
     statSync(pdfDir);
     await cpSync(pdfDir, lddPdfDir, { recursive: true });
-    console.log('PDF folder has been copied to ' + lddPdfDir);
+    console.log(`PDF folder has been copied to ${relative(folders.root, lddPdfDir)}`);
   } catch (e) {
     console.error(e)
   }
 
   try {
-    const customerDir = join(folders.root, 'pdf', 'customers');
     statSync(customerDir);
-    const customerFolders = readdirSync(customerDir, { withFileTypes: true })
-      .filter(dirent => dirent.isDirectory())
-      .map(dirent => dirent.name);
+    const customerTarget = join(lddPdfDir, customer);
+    mkdirSync(customerTarget, { recursive: true });
+    const jsReferences = [
+      'pdf.js'
+    ];
+    const cssReferences = [
+      'pdf.css'
+    ];
 
     try {
-      for (let i = 0; i < customerFolders.length; i++) {
-        const customer = customerFolders[i];
-        const customerFolder = join(customerDir, customer);
-        const customerTarget = join(lddPdfDir, customer);
-
-        const jsReferences = [
-          'pdf.js'
-        ];
-        const cssReferences = [
-          'pdf.css'
-        ];
-
-        try {
-          const tsPath = join(customerFolder, 'custom.ts');
-          statSync(tsPath);
-          const config = {
-            css: {
-              preprocessorOptions: {
-                scss: {
-                  api: 'modern-compiler',
-                },
-              },
+      const tsPath = join(customerDir, 'custom.ts');
+      statSync(tsPath);
+      const config = {
+        css: {
+          preprocessorOptions: {
+            scss: {
+              api: 'modern-compiler',
             },
-            base: './',
-            build: {
-              outDir: customerTarget,
-              lib: {
-                fileName: 'custom',
-                entry: tsPath,
-                formats: ['es'],
-              },
-            },
-            publicDir: false,
-          };
+          },
+        },
+        base: './',
+        build: {
+          outDir: customerTarget,
+          lib: {
+            fileName: 'custom',
+            entry: tsPath,
+            formats: ['es'],
+          },
+        },
+        publicDir: false,
+      };
 
-          try {
-            await viteBuild(config);
-          } catch (e) {
-            console.error(e);
-          }
-
-          try {
-            statSync(join(customerTarget, 'custom.js'));
-            jsReferences.push(`${customer}/custom.js`);
-          } catch (e) {}
-
-          try {
-            statSync(join(customerTarget, 'custom.css'));
-            cssReferences.push(`${customer}/custom.css`);
-          } catch (e) {}
-
-
-        } catch (e) {}
-
-        const files = await glob(join(customerFolder, '**', '*'), { withFileTypes: true });
-        for (const file of files) {
-          if (file.isFile()) {
-            if (!file.name.endsWith('.scss') && !file.name.endsWith('.ts') && !file.name.endsWith('.tsx')) {
-              const from = file.fullpath();
-              const to = join(customerTarget, relative(customerFolder, file.fullpath()));
-              await cpSync(from, to);
-              console.log(`Copy /${relative(folders.root, from)} to /${relative(folders.root, to)}`);
-            }
-            if (file.name.endsWith('.css')) {
-              cssReferences.push(`${relative(customerDir, file.fullpath())}`);
-            }
-            if (file.name.endsWith('.js')) {
-              jsReferences.push(`${relative(customerDir, file.fullpath())}`);
-            }
-          }
-        }
-
-        const nsWowUrl = `${nsWowInternalLddUrl}/${lddJson.name}/${lddJson.version}/pdf`;
-
-        const pdfConfig = [
-          '<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">'
-        ];
-        cssReferences.forEach( p => {
-          pdfConfig.push(`  <userStyleSheets><uri>${nsWowUrl}/${p}</uri></userStyleSheets>`);
-        })
-
-        jsReferences.forEach( p => {
-          pdfConfig.push(`  <userScripts><uri>${nsWowUrl}/${p}</uri></userScripts>`);
-        })
-
-        pdfConfig.push(`</configuration>`);
-
-        const pdfConfigPath = join(customerTarget, 'pdf-configuration.xml');
-        try {
-          statSync(customerTarget);
-        } catch (e) {
-          mkdirSync(customerTarget, { recursive: true });
-        }
-
-        await writeFileSync(pdfConfigPath, pdfConfig.join('\n'));
-        console.log(`Create PDF configuration file /${relative(folders.root, pdfConfigPath)}`);
+      try {
+        await viteBuild(config);
+      } catch (e) {
+        console.error(e);
       }
-    } catch (e) {
-      console.error(e)
-    }
+      jsReferences.push(join(customer, 'custom.js'));
+    } catch (e) {}
+
+    try {
+      const cssPath = join(customerTarget, 'custom.css');
+      statSync(cssPath);
+      cssReferences.push(join(customer, 'custom.css'));
+    } catch (e) {}
+
+    try {
+      const publicDir = join(customerDir, 'public');
+      statSync(publicDir);
+      const publicTarget = join(customerTarget, 'public');
+      await cpSync(publicDir, publicTarget, { recursive: true });
+      console.log(`Customer ${customer} public folder has been copied to ${relative(folders.root, publicTarget)}`);
+
+      const publicFiles = await glob(join(publicTarget, '**', '*'), { withFileTypes: true });
+
+      for (const publicFile of publicFiles) {
+        if (publicFile.isFile()) {
+          if (publicFile.name.endsWith('.css')) {
+            cssReferences.push(`${relative(lddPdfDir, publicFile.fullpath())}`);
+          }
+          if (publicFile.name.endsWith('.js')) {
+            jsReferences.push(`${relative(lddPdfDir, publicFile.fullpath())}`);
+          }
+        }
+      }
+    } catch (e) {}
+
+    const pdfXmlStart = `<configuration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n`;
+    const pdfXmlEnd = `\n</configuration>`;
+    const nsWowUrl = `${nsWowInternalLddUrl}/${lddJson.name}/${lddJson.version}/pdf`;
+
+    const pdfConfig = [];
+    cssReferences.forEach( p => {
+      pdfConfig.push(`  <userStyleSheets><uri>${nsWowUrl}/${p}</uri></userStyleSheets>`);
+    })
+
+    jsReferences.forEach( p => {
+      pdfConfig.push(`  <userScripts><uri>${nsWowUrl}/${p}</uri></userScripts>`);
+    })
+
+    const pdfConfigContent = pdfXmlStart
+      + `  <appendLog>false</appendLog>\n`
+      + pdfConfig.join('\n')
+      + pdfXmlEnd;
+    const pdfConfigPath = join(customerTarget, 'pdf-configuration.xml');
+    writeFileSync(pdfConfigPath, pdfConfigContent);
+    console.log(`Customer ${customer} PDF configuration file has been built to ${relative(folders.root, pdfConfigPath)}`);
+
+    const pdfConfigDebugContent = pdfXmlStart
+      + `  <appendLog>true</appendLog>\n`
+      + `  <inspectableSettings><enabled>true</enabled></inspectableSettings>\n`
+      + `  <debugSettings><all>true</all></debugSettings>\n`
+      + pdfConfig.join('\n')
+      + pdfXmlEnd;
+    const pdfConfigDebugPath = join(customerTarget, 'pdf-configuration-debug.xml');
+    writeFileSync(pdfConfigDebugPath, pdfConfigDebugContent);
+    console.log(`Customer ${customer} PDF debug configuration file has been built to ${relative(folders.root, pdfConfigDebugPath)}`);
+
+    console.log(`Customer ${customer} PDF files has been built to ${relative(folders.root, customerTarget)}`);
+
+    console.log("\n");
   } catch (e) {}
 
   return true;
@@ -650,7 +654,8 @@ async function buildWord() {
  * @param {string} version
  * @return {Promise<void>} A Promise that resolves when the build process is completed or rejects if an error occurs.
  */
-async function build(version) {
+async function build(version, options) {
+
   try {
     await checkFolders();
     const packageJson = await readPackageJson();
@@ -672,6 +677,7 @@ async function build(version) {
     await buildWord();
     await buildXbrl();
     await buildLdd();
+    !options.customer || await buildPdfCustomer(options.customer);
     new LivingdocsDesignValidator(await readLivingDocsJson()).IsDesignValid();
     await zipApp();
     await zipLdd();


### PR DESCRIPTION
Pdf customers are now only started individually via a parameter.

The following command syntaxes are available for the build process with customer:
npx srl build --customer <customer-name>
npx srl build -c <customer-name>
npm run build -- --customer <customer-name>
npm run build -- -c <customer-name>

Or create a script in package.json with the command
srl build --customer <customer-name>
or
srl build -c <customer-name>