### PR TITLE
Epic/december 2025

### DIFF
--- a/livingdocs/100.Misc/010.anchor/anchor.html
+++ b/livingdocs/100.Misc/010.anchor/anchor.html
@@ -1,4 +1,4 @@
-<p class="srl-anchor srl-editor-component" data-remove-from-translate-plus="true" data-remove-from-xhtml="complete"
+<p class="srl-anchor srl-editor-component" data-remove-from-translate-plus="true" data-remove-from-word="complete" data-remove-from-xhtml="complete"
   data-is-anchor="true">
   <span class="srl-anchor__text srl-editor-component__text" doc-editable="anchor-text">
     Must start with a letter (A–Z or a–z); a number is not allowed. After the

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@multivisio/nswow",
   "version": "1.0.55",
   "description": "Manage srl templates, build and publish",
+  "repository": {
+    "url": "https://github.com/mmssolutionsio/simple-reporting-library"
+  },
   "bin": {
     "srl": "cli.js"
   },

--- a/scripts/beaver.js
+++ b/scripts/beaver.js
@@ -126,6 +126,11 @@ function hasPointsOutsideOfParentheses(text) {
   return false;
 }
 
+function isUnitSize(value) {
+  const unitSizePattern = /^-?\d*\.?\d+(px|em|rem|%|vw|vh|vmin|vmax|cm|mm|in|pt|pc|ex|ch)?$/;
+  return unitSizePattern.test(value);
+}
+
 /**
  * Converts a JavaScript object into SCSS variables.
  *
@@ -155,6 +160,7 @@ function makeScssVariables(values, indent = 2) {
     if (
       typeof values === 'string' &&
       values !== `""` &&
+      !isUnitSize(values) &&
       (hasPointsOutsideOfParentheses(values) ||
         hasCommasOutsideOfParentheses(values))
     ) {

--- a/scripts/build.d.ts
+++ b/scripts/build.d.ts
@@ -5,7 +5,7 @@
  * @param {string} version
  * @return {Promise<void>} A Promise that resolves when the build process is completed or rejects if an error occurs.
  */
-export function build(version: string, options: any): Promise<void>;
+export function build(version: string, options?: {}): Promise<void>;
 /**
  * Builds the project sequentially by executing a series of asynchronous tasks in a specific order.
  * This method is used to build the project in a predetermined sequence.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1065,7 +1065,11 @@ async function mapJs() {
 
   for (let i = 0; i < jsFiles.length; i++) {
     const file = jsFiles[i];
-    const className = camelCase(file.parent.name);
+    let className = file.parent.name.split('.');
+    if (className.length > 1) {
+      className.shift();
+    }
+    className = camelCase(className.join('.'));
     const path = [file.name];
     let parent = file.parent;
     while (parent) {

--- a/scripts/doPublish.js
+++ b/scripts/doPublish.js
@@ -17,6 +17,9 @@ export async function doPublish(version = null) {
   try {
     const publishVersion = await preparePublish(version);
 
+    await execSync(`npm publish`, { stdio: 'inherit' });
+
+    /*
     const tag = `v${publishVersion.split('.')[0]}-lts`;
 
     await execSync(`npm publish --tag ${tag}`, { stdio: 'inherit' });
@@ -31,6 +34,8 @@ export async function doPublish(version = null) {
         },
       );
     }
+
+     */
 
     console.log(
       `Package ${packageName}@${publishVersion} published successfully!`,

--- a/scss/spacer/root.scss
+++ b/scss/spacer/root.scss
@@ -1,6 +1,7 @@
 @use "variables";
 @use "../system";
 @use "sass:map";
+@use "sass:meta";
 
 @each $spacer, $spacerValue in variables.$spacer {
   $varName: #{variables.$variable-prefix}spacer-#{$spacer};
@@ -20,35 +21,70 @@
   @if map.has-key($spacerValue, media) {
     @each $breakpoint, $breakpointValue in map.get($spacerValue, media) {
       @if $breakpoint == print {
-        @include system.add-root-style(
-                        $varName,
-                        system.size-unit(map.get($breakpointValue, size)),
-                        print
-        );
-      } @else if $breakpoint == up {
-        @each $upBreakpoint, $upBreakpointValue in $breakpointValue {
+        @if (meta.type-of($breakpointValue) == 'map' and map.has-key($breakpointValue, size)) {
           @include system.add-root-style(
                           $varName,
-                          system.size-unit($upBreakpointValue),
-                          $upBreakpoint,
-                          up
+                          system.size-unit(map.get($breakpointValue, size)),
+                          print
           );
+        } @else {
+          @include system.add-root-style(
+                          $varName,
+                          system.size-unit($breakpointValue),
+                          print
+          );
+        }
+
+      } @else if $breakpoint == up {
+        @each $upBreakpoint, $upBreakpointValue in $breakpointValue {
+          @if meta.type-of($upBreakpointValue) == 'map' and map.has-key($upBreakpointValue, size) {
+            @include system.add-root-style(
+                            $varName,
+                            system.size-unit(map.get($upBreakpointValue, size)),
+                            $upBreakpoint,
+                            up
+            );
+          } @else {
+            @include system.add-root-style(
+                            $varName,
+                            system.size-unit($upBreakpointValue),
+                            $upBreakpoint,
+                            up
+            );
+          }
         }
       } @else if $breakpoint == down {
         @each $downBreakpoint, $downBreakpointValue in $breakpointValue {
-          @include system.add-root-style(
-                          $varName,
-                          system.size-unit($downBreakpointValue),
-                          $downBreakpoint,
-                          down
-          );
+          @if meta.type-of($downBreakpointValue) == 'map' and map.has-key($downBreakpointValue, size) {
+            @include system.add-root-style(
+                            $varName,
+                            system.size-unit(map.get($downBreakpointValue, size)),
+                            $downBreakpoint,
+                            down
+            );
+          } @else {
+            @include system.add-root-style(
+                            $varName,
+                            system.size-unit($downBreakpointValue),
+                            $downBreakpoint,
+                            down
+            );
+          }
         }
       } @else {
-        @include system.add-root-style(
-                        $varName,
-                        system.size-unit($breakpointValue),
-                        $breakpoint
-        );
+        @if meta.type-of($breakpointValue) == 'map' and map.has-key($breakpointValue, size) {
+          @include system.add-root-style(
+                          $varName,
+                          system.size-unit(map.get($breakpointValue, size)),
+                          $breakpoint
+          );
+        } @else {
+          @include system.add-root-style(
+                          $varName,
+                          system.size-unit($breakpointValue),
+                          $breakpoint
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
- changed `data-remove-from-xbrl` to `data-remove-from-xhtml`
- intpret font size values from js to scss as value and not as string
- fixed spacer logic for repsonsive
- make app.ts in livingdocs components backwards compatible