### PR TITLE
fixed matching patterns for lead and paragraph

### DIFF
--- a/dev/livingdocs.config.json
+++ b/dev/livingdocs.config.json
@@ -521,8 +521,8 @@
       "identifier": "wp_cf_excerpt",
       "type": "text",
       "matches": [
-        "lead.text",
-        "paragraph.text"
+        "lead.lead",
+        "paragraph.paragraph"
       ]
     },
     {


### PR DESCRIPTION
- fixed wrong editable names for meta matchings